### PR TITLE
Refactor/skeletal render

### DIFF
--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/MeshRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/MeshRenderPass.cpp
@@ -1,0 +1,255 @@
+#include "MeshRenderPass.h"
+
+#include <array>
+
+#include "EngineLoop.h"
+#include "World/World.h"
+
+#include "RendererHelpers.h"
+#include "ShadowManager.h"
+#include "ShadowRenderPass.h"
+#include "UnrealClient.h"
+#include "Math/JungleMath.h"
+
+#include "UObject/UObjectIterator.h"
+#include "UObject/Casts.h"
+
+#include "D3D11RHI/DXDBufferManager.h"
+#include "D3D11RHI/GraphicDevice.h"
+#include "D3D11RHI/DXDShaderManager.h"
+
+#include "BaseGizmos/GizmoBaseComponent.h"
+#include "Engine/EditorEngine.h"
+
+#include "PropertyEditor/ShowFlags.h"
+
+#include "UnrealEd/EditorViewportClient.h"
+#include "Components/Light/PointLightComponent.h"
+
+FMeshRenderPassBase::FMeshRenderPassBase()
+    : BufferManager(nullptr)
+    , Graphics(nullptr)
+    , ShaderManager(nullptr)
+{
+}
+
+FMeshRenderPassBase::~FMeshRenderPassBase()
+{
+    ReleaseShader();
+}
+
+void FMeshRenderPassBase::Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManager)
+{
+    BufferManager = InBufferManager;
+    Graphics = InGraphics;
+    ShaderManager = InShaderManager;
+
+    CreateShader();
+}
+
+void FMeshRenderPassBase::InitializeShadowManager(FShadowManager* InShadowManager)
+{
+    ShadowManager = InShadowManager;
+}
+
+
+void FMeshRenderPassBase::PrepareRenderState(const std::shared_ptr<FEditorViewportClient>& Viewport)
+{
+    const EViewModeIndex ViewMode = Viewport->GetViewMode();
+
+    ChangeViewMode(ViewMode);
+
+    Graphics->DeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+    TArray<FString> PSBufferKeys = {
+        TEXT("FLightInfoBuffer"),
+        TEXT("FMaterialConstants"),
+        TEXT("FLitUnlitConstants"),
+        TEXT("FSubMeshConstants"),
+        TEXT("FTextureConstants"),
+    };
+
+    BufferManager->BindConstantBuffers(PSBufferKeys, 0, EShaderStage::Pixel);
+    BufferManager->BindConstantBuffer(TEXT("FDiffuseMultiplier"), 6, EShaderStage::Pixel);
+
+    BufferManager->BindConstantBuffer(TEXT("FLightInfoBuffer"), 0, EShaderStage::Vertex);
+    BufferManager->BindConstantBuffer(TEXT("FMaterialConstants"), 1, EShaderStage::Vertex);
+    BufferManager->BindConstantBuffer(TEXT("FObjectConstantBuffer"), 12, EShaderStage::Vertex);
+
+
+    Graphics->DeviceContext->RSSetViewports(1, &Viewport->GetViewportResource()->GetD3DViewport());
+
+    const EResourceType ResourceType = EResourceType::ERT_Scene;
+    FViewportResource* ViewportResource = Viewport->GetViewportResource();
+    FRenderTargetRHI* RenderTargetRHI = ViewportResource->GetRenderTarget(ResourceType);
+    FDepthStencilRHI* DepthStencilRHI = ViewportResource->GetDepthStencil(ResourceType);
+
+    Graphics->DeviceContext->OMSetRenderTargets(1, &RenderTargetRHI->RTV, DepthStencilRHI->DSV);
+}
+
+void FMeshRenderPassBase::UpdateObjectConstant(const FMatrix& WorldMatrix, const FVector4& UUIDColor, bool bIsSelected) const
+{
+    FObjectConstantBuffer ObjectData = {};
+    ObjectData.WorldMatrix = WorldMatrix;
+    ObjectData.InverseTransposedWorld = FMatrix::Transpose(FMatrix::Inverse(WorldMatrix));
+    ObjectData.UUIDColor = UUIDColor;
+    ObjectData.bIsSelected = bIsSelected;
+
+    BufferManager->UpdateConstantBuffer(TEXT("FObjectConstantBuffer"), ObjectData);
+}
+
+void FMeshRenderPassBase::UpdateLitUnlitConstant(int32 isLit) const
+{
+    FLitUnlitConstants Data;
+    Data.bIsLit = isLit;
+    BufferManager->UpdateConstantBuffer(TEXT("FLitUnlitConstants"), Data);
+}
+
+void FMeshRenderPassBase::CreateShader()
+{
+    // Begin Debug Shaders
+    HRESULT hr = ShaderManager->AddPixelShader(L"StaticMeshPixelShaderDepth", L"Shaders/StaticMeshPixelShaderDepth.hlsl", "mainPS");
+    if (FAILED(hr))
+    {
+        return;
+    }
+    hr = ShaderManager->AddPixelShader(L"StaticMeshPixelShaderWorldNormal", L"Shaders/StaticMeshPixelShaderWorldNormal.hlsl", "mainPS");
+    if (FAILED(hr))
+    {
+        return;
+    }
+    hr = ShaderManager->AddPixelShader(L"StaticMeshPixelShaderWorldTangent", L"Shaders/StaticMeshPixelShaderWorldTangent.hlsl", "mainPS");
+    if (FAILED(hr))
+    {
+        return;
+    }
+    // End Debug Shaders
+
+#pragma region UberShader
+    D3D_SHADER_MACRO DefinesGouraud[] =
+    {
+        { GOURAUD, "1" },
+        { nullptr, nullptr }
+    };
+    hr = ShaderManager->AddPixelShader(L"GOURAUD_StaticMeshPixelShader", L"Shaders/StaticMeshPixelShader.hlsl", "mainPS", DefinesGouraud);
+    if (FAILED(hr))
+    {
+        return;
+    }
+
+    D3D_SHADER_MACRO DefinesLambert[] =
+    {
+        { LAMBERT, "1" },
+        { nullptr, nullptr }
+    };
+    hr = ShaderManager->AddPixelShader(L"LAMBERT_StaticMeshPixelShader", L"Shaders/StaticMeshPixelShader.hlsl", "mainPS", DefinesLambert);
+    if (FAILED(hr))
+    {
+        return;
+    }
+
+    D3D_SHADER_MACRO DefinesBlinnPhong[] =
+    {
+        { PHONG, "1" },
+        { nullptr, nullptr }
+    };
+    hr = ShaderManager->AddPixelShader(L"PHONG_StaticMeshPixelShader", L"Shaders/StaticMeshPixelShader.hlsl", "mainPS", DefinesBlinnPhong);
+    if (FAILED(hr))
+    {
+        return;
+    }
+
+    D3D_SHADER_MACRO DefinesPBR[] =
+    {
+        { PBR, "1" },
+        { nullptr, nullptr }
+    };
+    hr = ShaderManager->AddPixelShader(L"PBR_StaticMeshPixelShader", L"Shaders/StaticMeshPixelShader.hlsl", "mainPS", DefinesPBR);
+    if (FAILED(hr))
+    {
+        return;
+    }
+#pragma endregion UberShader
+}
+
+void FMeshRenderPassBase::ReleaseShader()
+{
+
+}
+
+void FMeshRenderPassBase::ChangeViewMode(EViewModeIndex ViewMode)
+{
+    ID3D11VertexShader* VertexShader = nullptr;
+    ID3D11InputLayout* InputLayout = nullptr;
+    ID3D11PixelShader* PixelShader = nullptr;
+
+    switch (ViewMode)
+    {
+    case EViewModeIndex::VMI_Lit_Gouraud:
+        VertexShader = ShaderManager->GetVertexShaderByKey(L"GOURAUD_StaticMeshVertexShader");
+        InputLayout = ShaderManager->GetInputLayoutByKey(L"GOURAUD_StaticMeshVertexShader");
+        PixelShader = ShaderManager->GetPixelShaderByKey(L"GOURAUD_StaticMeshPixelShader");
+        UpdateLitUnlitConstant(1);
+        break;
+    case EViewModeIndex::VMI_Lit_Lambert:
+        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
+        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
+        PixelShader = ShaderManager->GetPixelShaderByKey(L"LAMBERT_StaticMeshPixelShader");
+        UpdateLitUnlitConstant(1);
+        break;
+    case EViewModeIndex::VMI_Lit_BlinnPhong:
+        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
+        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
+        PixelShader = ShaderManager->GetPixelShaderByKey(L"PHONG_StaticMeshPixelShader");
+        UpdateLitUnlitConstant(1);
+        break;
+    case EViewModeIndex::VMI_LIT_PBR:
+        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
+        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
+        PixelShader = ShaderManager->GetPixelShaderByKey(L"PBR_StaticMeshPixelShader");
+        UpdateLitUnlitConstant(1);
+        break;
+    case EViewModeIndex::VMI_Wireframe:
+    case EViewModeIndex::VMI_Unlit:
+        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
+        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
+        PixelShader = ShaderManager->GetPixelShaderByKey(L"LAMBERT_StaticMeshPixelShader");
+        UpdateLitUnlitConstant(0);
+        break;
+    case EViewModeIndex::VMI_SceneDepth:
+        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
+        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
+        PixelShader = ShaderManager->GetPixelShaderByKey(L"StaticMeshPixelShaderDepth");
+        UpdateLitUnlitConstant(0);
+        break;
+    case EViewModeIndex::VMI_WorldNormal:
+        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
+        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
+        PixelShader = ShaderManager->GetPixelShaderByKey(L"StaticMeshPixelShaderWorldNormal");
+        UpdateLitUnlitConstant(0);
+        break;
+    case EViewModeIndex::VMI_WorldTangent:
+        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
+        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
+        PixelShader = ShaderManager->GetPixelShaderByKey(L"StaticMeshPixelShaderWorldTangent");
+        UpdateLitUnlitConstant(0);
+        break;
+        // HeatMap ViewMode 등
+    default:
+        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
+        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
+        PixelShader = ShaderManager->GetPixelShaderByKey(L"LAMBERT_StaticMeshPixelShader");
+        UpdateLitUnlitConstant(1);
+        break;
+    }
+
+    // Rasterizer
+    Graphics->ChangeRasterizer(ViewMode);
+
+    // Setup
+    Graphics->DeviceContext->VSSetShader(VertexShader, nullptr, 0);
+    Graphics->DeviceContext->IASetInputLayout(InputLayout);
+    Graphics->DeviceContext->PSSetShader(PixelShader, nullptr, 0);
+}
+
+

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/MeshRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/MeshRenderPass.h
@@ -48,14 +48,6 @@ public:
 
 protected:
 
-    /*
-    ID3D11VertexShader* VertexShader;
-    ID3D11InputLayout* InputLayout;
-
-    ID3D11PixelShader* PixelShader;
-    ID3D11PixelShader* DebugDepthShader;
-    ID3D11PixelShader* DebugWorldNormalShader;
-    */
 
     FDXDBufferManager* BufferManager;
     FGraphicsDevice* Graphics;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/MeshRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/MeshRenderPass.h
@@ -1,0 +1,65 @@
+#pragma once
+#include "IRenderPass.h"
+#include "EngineBaseTypes.h"
+#include "Container/Set.h"
+
+#include "Define.h"
+#include "Components/Light/PointLightComponent.h"
+
+class FShadowManager;
+class FDXDShaderManager;
+class UWorld;
+class UMaterial;
+class FEditorViewportClient;
+class FShadowRenderPass;
+
+class FMeshRenderPassBase : public IRenderPass
+{
+public:
+    FMeshRenderPassBase();
+
+    virtual ~FMeshRenderPassBase();
+
+    virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManager) override;
+
+    void InitializeShadowManager(class FShadowManager* InShadowManager);
+
+    virtual void PrepareRenderArr() = 0;
+
+    virtual void Render(const std::shared_ptr<FEditorViewportClient>& Viewport) = 0;
+
+    virtual void ClearRenderArr() = 0;
+
+    virtual void PrepareRenderState(const std::shared_ptr<FEditorViewportClient>& Viewport);
+
+    void UpdateObjectConstant(const FMatrix& WorldMatrix, const FVector4& UUIDColor, bool bIsSelected) const;
+
+    void UpdateLitUnlitConstant(int32 isLit) const;
+
+    virtual void RenderPrimitive(ID3D11Buffer* pBuffer, UINT numVertices) const = 0;
+
+    virtual void RenderPrimitive(ID3D11Buffer* pVertexBuffer, UINT numVertices, ID3D11Buffer* pIndexBuffer, UINT numIndices) const = 0;
+
+    // Shader 관련 함수 (생성/해제 등)
+    void CreateShader();
+    void ReleaseShader();
+
+    void ChangeViewMode(EViewModeIndex ViewMode);
+
+protected:
+
+    /*
+    ID3D11VertexShader* VertexShader;
+    ID3D11InputLayout* InputLayout;
+
+    ID3D11PixelShader* PixelShader;
+    ID3D11PixelShader* DebugDepthShader;
+    ID3D11PixelShader* DebugWorldNormalShader;
+    */
+
+    FDXDBufferManager* BufferManager;
+    FGraphicsDevice* Graphics;
+    FDXDShaderManager* ShaderManager;
+
+    FShadowManager* ShadowManager;
+};

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/Renderer.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/Renderer.cpp
@@ -8,6 +8,7 @@
 #include "D3D11RHI/DXDShaderManager.h"
 #include "RendererHelpers.h"
 #include "StaticMeshRenderPass.h"
+#include "SkeletalMeshRenderPass.h"
 #include "WorldBillboardRenderPass.h"
 #include "EditorBillboardRenderPass.h"
 #include "GizmoRenderPass.h"
@@ -52,6 +53,7 @@ void FRenderer::Initialize(FGraphicsDevice* InGraphics, FDXDBufferManager* InBuf
     CreateCommonShader();
     
     StaticMeshRenderPass = new FStaticMeshRenderPass();
+    SkeletalMeshRenderPass = new FSkeletalMeshRenderPass();
     WorldBillboardRenderPass = new FWorldBillboardRenderPass();
     EditorBillboardRenderPass = new FEditorBillboardRenderPass();
     GizmoRenderPass = new FGizmoRenderPass();
@@ -78,6 +80,8 @@ void FRenderer::Initialize(FGraphicsDevice* InGraphics, FDXDBufferManager* InBuf
     
     StaticMeshRenderPass->Initialize(BufferManager, Graphics, ShaderManager);
     StaticMeshRenderPass->InitializeShadowManager(ShadowManager);
+    SkeletalMeshRenderPass->Initialize(BufferManager, Graphics, ShaderManager);
+    SkeletalMeshRenderPass->InitializeShadowManager(ShadowManager);
     WorldBillboardRenderPass->Initialize(BufferManager, Graphics, ShaderManager);
     EditorBillboardRenderPass->Initialize(BufferManager, Graphics, ShaderManager);
     GizmoRenderPass->Initialize(BufferManager, Graphics, ShaderManager);
@@ -104,6 +108,7 @@ void FRenderer::Release()
     delete ShadowRenderPass;
 
     delete StaticMeshRenderPass;
+    delete SkeletalMeshRenderPass;
     delete WorldBillboardRenderPass;
     delete EditorBillboardRenderPass;
     delete GizmoRenderPass;
@@ -229,6 +234,7 @@ void FRenderer::PrepareRender(FViewportResource* ViewportResource) const
 void FRenderer::PrepareRenderPass() const
 {
     StaticMeshRenderPass->PrepareRenderArr();
+    SkeletalMeshRenderPass->PrepareRenderArr();
     ShadowRenderPass->PrepareRenderArr();
     GizmoRenderPass->PrepareRenderArr();
     WorldBillboardRenderPass->PrepareRenderArr();
@@ -243,6 +249,7 @@ void FRenderer::PrepareRenderPass() const
 void FRenderer::ClearRenderArr() const
 {
     StaticMeshRenderPass->ClearRenderArr();
+    SkeletalMeshRenderPass->ClearRenderArr();
     ShadowRenderPass->ClearRenderArr();
     WorldBillboardRenderPass->ClearRenderArr();
     EditorBillboardRenderPass->ClearRenderArr();
@@ -379,6 +386,11 @@ void FRenderer::RenderWorldScene(const std::shared_ptr<FEditorViewportClient>& V
             QUICK_SCOPE_CYCLE_COUNTER(StaticMeshPass_CPU)
             QUICK_GPU_SCOPE_CYCLE_COUNTER(StaticMeshPass_GPU, *GPUTimingManager)
             StaticMeshRenderPass->Render(Viewport);
+        }
+        {
+            QUICK_SCOPE_CYCLE_COUNTER(SkeletalMeshPass_CPU)
+            QUICK_GPU_SCOPE_CYCLE_COUNTER(SkeletalMeshPass_CPU, *GPUTimingManager)
+            SkeletalMeshRenderPass->Render(Viewport);
         }
     }
     

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/Renderer.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/Renderer.h
@@ -29,6 +29,7 @@ class FEditorViewportClient;
 class FViewportResource;
 
 class FStaticMeshRenderPass;
+class FSkeletalMeshRenderPass;
 class FWorldBillboardRenderPass;
 class FEditorBillboardRenderPass;
 class FGizmoRenderPass;
@@ -97,6 +98,7 @@ public:
     class FShadowRenderPass* ShadowRenderPass;
 
     FStaticMeshRenderPass* StaticMeshRenderPass = nullptr;
+    FSkeletalMeshRenderPass* SkeletalMeshRenderPass = nullptr;
     FWorldBillboardRenderPass* WorldBillboardRenderPass = nullptr;
     FEditorBillboardRenderPass* EditorBillboardRenderPass = nullptr;
     FGizmoRenderPass* GizmoRenderPass = nullptr;

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/SkeletalMeshRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/SkeletalMeshRenderPass.cpp
@@ -1,0 +1,258 @@
+#include "SkeletalMeshRenderPass.h"
+
+#include <array>
+
+#include "EngineLoop.h"
+#include "World/World.h"
+
+#include "RendererHelpers.h"
+#include "ShadowManager.h"
+#include "ShadowRenderPass.h"
+#include "UnrealClient.h"
+#include "Math/JungleMath.h"
+
+#include "UObject/UObjectIterator.h"
+#include "UObject/Casts.h"
+
+#include "D3D11RHI/DXDBufferManager.h"
+#include "D3D11RHI/GraphicDevice.h"
+#include "D3D11RHI/DXDShaderManager.h"
+
+// #include "Components/SkeletalMesh/SkeletalMeshComponent"
+
+#include "BaseGizmos/GizmoBaseComponent.h"
+#include "Engine/EditorEngine.h"
+
+#include "PropertyEditor/ShowFlags.h"
+
+#include "UnrealEd/EditorViewportClient.h"
+#include "Components/Light/PointLightComponent.h"
+#include "Contents/Actors/Fish.h"
+
+FSkeletalMeshRenderPass::FSkeletalMeshRenderPass()
+    : FMeshRenderPassBase()
+{
+
+}
+
+FSkeletalMeshRenderPass::~FSkeletalMeshRenderPass()
+{
+    ReleaseShader();
+}
+
+void FSkeletalMeshRenderPass::PrepareRenderArr()
+{
+    // TODO SkeletalMesh 에 관한 내용 기입 필요 아래는 StaticMesh 예시
+    /*for (const auto iter : TObjectRange<UStaticMeshComponent>())
+    {
+        if (!Cast<UGizmoBaseComponent>(iter) && iter->GetWorld() == GEngine->ActiveWorld)
+        {
+            if (iter->GetOwner() && !iter->GetOwner()->IsHidden())
+            {
+                StaticMeshComponents.Add(iter);
+            }
+        }
+    }*/
+}
+
+void FSkeletalMeshRenderPass::Render(const std::shared_ptr<FEditorViewportClient>& Viewport)
+{
+    ShadowManager->BindResourcesForSampling();
+
+    PrepareRenderState(Viewport);
+
+    RenderAllSkeletalMeshes(Viewport);
+
+    // 렌더 타겟 해제
+    Graphics->DeviceContext->OMSetRenderTargets(0, nullptr, nullptr);
+    ID3D11ShaderResourceView* nullSRV = nullptr;
+    Graphics->DeviceContext->PSSetShaderResources(static_cast<int>(EShaderSRVSlot::SRV_PointLight), 1, &nullSRV); // t51 슬롯을 NULL로 설정
+    Graphics->DeviceContext->PSSetShaderResources(static_cast<int>(EShaderSRVSlot::SRV_DirectionalLight), 1, &nullSRV); // t51 슬롯을 NULL로 설정
+    Graphics->DeviceContext->PSSetShaderResources(static_cast<int>(EShaderSRVSlot::SRV_SpotLight), 1, &nullSRV); // t51 슬롯을 NULL로 설정
+
+    // 머티리얼 리소스 해제
+    constexpr UINT NumViews = static_cast<UINT>(EMaterialTextureSlots::MTS_MAX);
+
+    ID3D11ShaderResourceView* NullSRVs[NumViews] = { nullptr };
+    ID3D11SamplerState* NullSamplers[NumViews] = { nullptr };
+
+    Graphics->DeviceContext->PSSetShaderResources(0, NumViews, NullSRVs);
+    Graphics->DeviceContext->PSSetSamplers(0, NumViews, NullSamplers);
+
+    // for Gouraud shading
+    ID3D11ShaderResourceView* NullSRV[1] = { nullptr };
+    ID3D11SamplerState* NullSampler[1] = { nullptr };
+    Graphics->DeviceContext->VSSetShaderResources(0, 1, NullSRV);
+    Graphics->DeviceContext->VSSetSamplers(0, 1, NullSampler);
+
+    // @todo 리소스 언바인딩 필요한가? - 답변: 네.
+    // SRV 해제
+    ID3D11ShaderResourceView* NullSRVs2[14] = { nullptr };
+    Graphics->DeviceContext->PSSetShaderResources(0, 14, NullSRVs2);
+
+    // 상수버퍼 해제
+    ID3D11Buffer* NullPSBuffer[9] = { nullptr };
+    Graphics->DeviceContext->PSSetConstantBuffers(0, 9, NullPSBuffer);
+    ID3D11Buffer* NullVSBuffer[2] = { nullptr };
+    Graphics->DeviceContext->VSSetConstantBuffers(0, 2, NullVSBuffer);
+}
+
+void FSkeletalMeshRenderPass::ClearRenderArr()
+{
+    // TODO SkeletalMeshCOmponents Empty 필요
+    //StaticMeshComponents.Empty();
+}
+
+void FSkeletalMeshRenderPass::RenderAllSkeletalMeshesForPointLight(const std::shared_ptr<FEditorViewportClient>& Viewport, UPointLightComponent*& PointLight)
+{
+    // TODO Skeletal 로 아래 내용 교체 필요
+
+    //for (UStaticMeshComponent* Comp : StaticMeshComponents)
+    //{
+    //    if (!Comp || !Comp->GetStaticMesh()) { continue; }
+
+    //    FStaticMeshRenderData* RenderData = Comp->GetStaticMesh()->GetRenderData();
+    //    if (RenderData == nullptr) { continue; }
+
+    //    UEditorEngine* Engine = Cast<UEditorEngine>(GEngine);
+
+    //    FMatrix WorldMatrix = Comp->GetWorldMatrix();
+
+    //    //ShadowRenderPass->UpdateCubeMapConstantBuffer(PointLight, WorldMatrix);
+
+    //    RenderPrimitive(RenderData, Comp->GetStaticMesh()->GetMaterials(), Comp->GetOverrideMaterials(), Comp->GetselectedSubMeshIndex());
+    //}
+}
+
+void FSkeletalMeshRenderPass::RenderAllSkeletalMeshes(const std::shared_ptr<FEditorViewportClient>& Viewport)
+{
+    // TODO 아래 StaticMesh 내용 대신에 SkeletalMesh 내용 넣기
+
+    /*for (UStaticMeshComponent* Comp : StaticMeshComponents)
+    {
+        if (!Comp || !Comp->GetStaticMesh())
+        {
+            continue;
+        }
+
+        FStaticMeshRenderData* RenderData = Comp->GetStaticMesh()->GetRenderData();
+        if (RenderData == nullptr)
+        {
+            continue;
+        }
+
+        UEditorEngine* Engine = Cast<UEditorEngine>(GEngine);
+
+        USceneComponent* SelectedComponent = Engine->GetSelectedComponent();
+        AActor* SelectedActor = Engine->GetSelectedActor();
+
+        USceneComponent* TargetComponent = nullptr;
+
+        if (SelectedComponent != nullptr)
+        {
+            TargetComponent = SelectedComponent;
+        }
+        else if (SelectedActor != nullptr)
+        {
+            TargetComponent = SelectedActor->GetRootComponent();
+        }
+
+        FMatrix WorldMatrix = Comp->GetWorldMatrix();
+        FVector4 UUIDColor = Comp->EncodeUUID() / 255.0f;
+        const bool bIsSelected = (Engine && TargetComponent == Comp);
+
+        UpdateObjectConstant(WorldMatrix, UUIDColor, bIsSelected);
+
+#pragma region W08
+        FDiffuseMultiplier DM = {};
+        DM.DiffuseMultiplier = 0.f;
+        if (AFish* Fish = Cast<AFish>(Comp->GetOwner()))
+        {
+            if (!Fish->IsDead())
+            {
+                DM.DiffuseMultiplier = 1.f - Fish->GetHealthPercent();
+            }
+        }
+        DM.DiffuseOverrideColor = FVector(0.55f, 0.45f, 0.067f);
+        BufferManager->UpdateConstantBuffer(TEXT("FDiffuseMultiplier"), DM);
+#pragma endregion W08
+
+        RenderPrimitive(RenderData, Comp->GetStaticMesh()->GetMaterials(), Comp->GetOverrideMaterials(), Comp->GetselectedSubMeshIndex());
+
+        if (Viewport->GetShowFlag() & static_cast<uint64>(EEngineShowFlags::SF_AABB))
+        {
+            FEngineLoop::PrimitiveDrawBatch.AddAABBToBatch(Comp->GetBoundingBox(), Comp->GetWorldLocation(), WorldMatrix);
+        }
+    }*/
+}
+
+void FSkeletalMeshRenderPass::RenderPrimitive(FSkeletalMeshRenderData* RenderData, TArray<FSkeletalMaterial*> Materials, TArray<UMaterial*> OverrideMaterials, int SelectedSubMeshIndex) const
+{
+    // TODO 아래 StaticMesh 내용 Skeletal로 교체하여 작업 필요
+
+    /*UINT Stride = sizeof(FStaticMeshVertex);
+    UINT Offset = 0;
+
+    FVertexInfo VertexInfo;
+    BufferManager->CreateVertexBuffer(RenderData->ObjectName, RenderData->Vertices, VertexInfo);
+
+    Graphics->DeviceContext->IASetVertexBuffers(0, 1, &VertexInfo.VertexBuffer, &Stride, &Offset);
+
+    FIndexInfo IndexInfo;
+    BufferManager->CreateIndexBuffer(RenderData->ObjectName, RenderData->Indices, IndexInfo);
+    if (IndexInfo.IndexBuffer)
+    {
+        Graphics->DeviceContext->IASetIndexBuffer(IndexInfo.IndexBuffer, DXGI_FORMAT_R32_UINT, 0);
+    }
+
+    if (RenderData->MaterialSubsets.Num() == 0)
+    {
+        Graphics->DeviceContext->DrawIndexed(RenderData->Indices.Num(), 0, 0);
+        return;
+    }
+
+    for (int SubMeshIndex = 0; SubMeshIndex < RenderData->MaterialSubsets.Num(); SubMeshIndex++)
+    {
+        uint32 MaterialIndex = RenderData->MaterialSubsets[SubMeshIndex].MaterialIndex;
+
+        FSubMeshConstants SubMeshData = (SubMeshIndex == SelectedSubMeshIndex) ? FSubMeshConstants(true) : FSubMeshConstants(false);
+
+        BufferManager->UpdateConstantBuffer(TEXT("FSubMeshConstants"), SubMeshData);
+
+        if (OverrideMaterials[MaterialIndex] != nullptr)
+        {
+            MaterialUtils::UpdateMaterial(BufferManager, Graphics, OverrideMaterials[MaterialIndex]->GetMaterialInfo());
+        }
+        else
+        {
+            MaterialUtils::UpdateMaterial(BufferManager, Graphics, Materials[MaterialIndex]->Material->GetMaterialInfo());
+        }
+
+        uint32 StartIndex = RenderData->MaterialSubsets[SubMeshIndex].IndexStart;
+        uint32 IndexCount = RenderData->MaterialSubsets[SubMeshIndex].IndexCount;
+        Graphics->DeviceContext->DrawIndexed(IndexCount, StartIndex, 0);
+    }*/
+}
+
+void FSkeletalMeshRenderPass::RenderPrimitive(ID3D11Buffer* pBuffer, UINT numVertices) const
+{
+    // 현재까지는 실질적으로 FStaticMeshVetex를 사용해도 문제가 전혀 없으므로 아래 코드 그대로 사용
+    // 추후 GPU SKinning과 같은 작업을 하게되면 수정 필요
+    UINT Stride = sizeof(FStaticMeshVertex);
+    UINT Offset = 0;
+    Graphics->DeviceContext->IASetVertexBuffers(0, 1, &pBuffer, &Stride, &Offset);
+    Graphics->DeviceContext->Draw(numVertices, 0);
+}
+
+void FSkeletalMeshRenderPass::RenderPrimitive(ID3D11Buffer* pVertexBuffer, UINT numVertices, ID3D11Buffer* pIndexBuffer, UINT numIndices) const
+{
+    // 현재까지는 실질적으로 FStaticMeshVetex를 사용해도 문제가 전혀 없으므로 아래 코드 그대로 사용
+    // 추후 GPU SKinning과 같은 작업을 하게되면 수정 필요
+    UINT Stride = sizeof(FStaticMeshVertex);
+    UINT Offset = 0;
+    Graphics->DeviceContext->IASetVertexBuffers(0, 1, &pVertexBuffer, &Stride, &Offset);
+    Graphics->DeviceContext->IASetIndexBuffer(pIndexBuffer, DXGI_FORMAT_R32_UINT, 0);
+    Graphics->DeviceContext->DrawIndexed(numIndices, 0, 0);
+}
+
+

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/SkeletalMeshRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/SkeletalMeshRenderPass.h
@@ -1,18 +1,57 @@
 #pragma once
-#include "IRenderPass.h"
-#include "RendererHelpers.h"
-#include "Container/Array.h"
 #include "MeshRenderPass.h"
+#include "EngineBaseTypes.h"
+#include "Container/Set.h"
 
+#include "Define.h"
+#include "Components/Light/PointLightComponent.h"
 
-// 전방선언 해둘게요 해당 양식 맞춰서 이후에 수정 필요합니다.
-class USkeletalMeshComponent;
+struct FSkeletalMeshRenderData; // TODO 해당 구조체 구현 필요    만약 Static으로 해도 문제가 없으면 바꿔서 쓰기
+class FShadowManager;
+class FDXDShaderManager;
+class UWorld;
 class UMaterial;
-
-struct FMatrix;
-struct FVector4;
-struct FStaticMaterial;
-struct FStaticMeshRenderData;
-struct ID3D11Buffer;
+class FEditorViewportClient;
+class USkeletalMeshComponent;    // TODO 해당 클래스 구현 필요   만약 Static으로 해도 문제가 없으면 바꿔서 쓰기
+struct FSkeletalMaterial;   // TODO 해당 구조체 구현 필요    만약 Static으로 해도 문제가 없으면 바꿔서 쓰기
+class FShadowRenderPass;
 
 
+class FSkeletalMeshRenderPass : public FMeshRenderPassBase
+{
+public:
+    FSkeletalMeshRenderPass();
+
+    virtual ~FSkeletalMeshRenderPass();
+
+    virtual void PrepareRenderArr() override;
+
+    virtual void Render(const std::shared_ptr<FEditorViewportClient>& Viewport) override;
+
+    virtual void ClearRenderArr() override;
+    void RenderAllSkeletalMeshesForPointLight(const std::shared_ptr<FEditorViewportClient>& Viewport, UPointLightComponent*& PointLight);
+
+    virtual void RenderAllSkeletalMeshes(const std::shared_ptr<FEditorViewportClient>& Viewport);
+
+    void RenderPrimitive(FSkeletalMeshRenderData* RenderData, TArray<FSkeletalMaterial*> Materials, TArray<UMaterial*> OverrideMaterials, int SelectedSubMeshIndex) const;
+
+    void RenderPrimitive(ID3D11Buffer* pBuffer, UINT numVertices) const override;
+
+    void RenderPrimitive(ID3D11Buffer* pVertexBuffer, UINT numVertices, ID3D11Buffer* pIndexBuffer, UINT numIndices) const override;
+
+    // Shader 관련 함수 (생성/해제 등) // FMeshRenderPass에서 구현했습니다.
+
+protected:
+
+
+    TArray<USkeletalMeshComponent*> SkeletalMeshComponents;
+
+    /*
+    ID3D11VertexShader* VertexShader;
+    ID3D11InputLayout* InputLayout;
+
+    ID3D11PixelShader* PixelShader;
+    ID3D11PixelShader* DebugDepthShader;
+    ID3D11PixelShader* DebugWorldNormalShader;
+    */
+};

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/SkeletalMeshRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/SkeletalMeshRenderPass.h
@@ -45,13 +45,4 @@ protected:
 
 
     TArray<USkeletalMeshComponent*> SkeletalMeshComponents;
-
-    /*
-    ID3D11VertexShader* VertexShader;
-    ID3D11InputLayout* InputLayout;
-
-    ID3D11PixelShader* PixelShader;
-    ID3D11PixelShader* DebugDepthShader;
-    ID3D11PixelShader* DebugWorldNormalShader;
-    */
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/SkeletalMeshRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/SkeletalMeshRenderPass.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "IRenderPass.h"
+#include "RendererHelpers.h"
+#include "Container/Array.h"
+#include "MeshRenderPass.h"
+
+
+// 전방선언 해둘게요 해당 양식 맞춰서 이후에 수정 필요합니다.
+class USkeletalMeshComponent;
+class UMaterial;
+
+struct FMatrix;
+struct FVector4;
+struct FStaticMaterial;
+struct FStaticMeshRenderData;
+struct ID3D11Buffer;
+
+

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/StaticMeshRenderPass.cpp
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/StaticMeshRenderPass.cpp
@@ -31,9 +31,7 @@
 
 
 FStaticMeshRenderPass::FStaticMeshRenderPass()
-    : BufferManager(nullptr)
-    , Graphics(nullptr)
-    , ShaderManager(nullptr)
+    : FMeshRenderPassBase()
 {
 }
 
@@ -42,167 +40,6 @@ FStaticMeshRenderPass::~FStaticMeshRenderPass()
     ReleaseShader();
 }
 
-void FStaticMeshRenderPass::CreateShader()
-{
-    // Begin Debug Shaders
-    HRESULT hr = ShaderManager->AddPixelShader(L"StaticMeshPixelShaderDepth", L"Shaders/StaticMeshPixelShaderDepth.hlsl", "mainPS");
-    if (FAILED(hr))
-    {
-        return;
-    }
-    hr = ShaderManager->AddPixelShader(L"StaticMeshPixelShaderWorldNormal", L"Shaders/StaticMeshPixelShaderWorldNormal.hlsl", "mainPS");
-    if (FAILED(hr))
-    {
-        return;
-    }
-    hr = ShaderManager->AddPixelShader(L"StaticMeshPixelShaderWorldTangent", L"Shaders/StaticMeshPixelShaderWorldTangent.hlsl", "mainPS");
-    if (FAILED(hr))
-    {
-        return;
-    }
-    // End Debug Shaders
-
-#pragma region UberShader
-    D3D_SHADER_MACRO DefinesGouraud[] =
-    {
-        { GOURAUD, "1" },
-        { nullptr, nullptr }
-    };
-    hr = ShaderManager->AddPixelShader(L"GOURAUD_StaticMeshPixelShader", L"Shaders/StaticMeshPixelShader.hlsl", "mainPS", DefinesGouraud);
-    if (FAILED(hr))
-    {
-        return;
-    }
-    
-    D3D_SHADER_MACRO DefinesLambert[] =
-    {
-        { LAMBERT, "1" },
-        { nullptr, nullptr }
-    };
-    hr = ShaderManager->AddPixelShader(L"LAMBERT_StaticMeshPixelShader", L"Shaders/StaticMeshPixelShader.hlsl", "mainPS", DefinesLambert);
-    if (FAILED(hr))
-    {
-        return;
-    }
-    
-    D3D_SHADER_MACRO DefinesBlinnPhong[] =
-    {
-        { PHONG, "1" },
-        { nullptr, nullptr }
-    };
-    hr = ShaderManager->AddPixelShader(L"PHONG_StaticMeshPixelShader", L"Shaders/StaticMeshPixelShader.hlsl", "mainPS", DefinesBlinnPhong);
-    if (FAILED(hr))
-    {
-        return;
-    }
-    
-    D3D_SHADER_MACRO DefinesPBR[] =
-    {
-        { PBR, "1" },
-        { nullptr, nullptr }
-    };
-    hr = ShaderManager->AddPixelShader(L"PBR_StaticMeshPixelShader", L"Shaders/StaticMeshPixelShader.hlsl", "mainPS", DefinesPBR);
-    if (FAILED(hr))
-    {
-        return;
-    }
-#pragma endregion UberShader
-}
-
-void FStaticMeshRenderPass::ReleaseShader()
-{
-    
-}
-
-void FStaticMeshRenderPass::ChangeViewMode(EViewModeIndex ViewMode)
-{
-    ID3D11VertexShader* VertexShader = nullptr;
-    ID3D11InputLayout* InputLayout = nullptr;
-    ID3D11PixelShader* PixelShader = nullptr;
-    
-    switch (ViewMode)
-    {
-    case EViewModeIndex::VMI_Lit_Gouraud:
-        VertexShader = ShaderManager->GetVertexShaderByKey(L"GOURAUD_StaticMeshVertexShader");
-        InputLayout = ShaderManager->GetInputLayoutByKey(L"GOURAUD_StaticMeshVertexShader");
-        PixelShader = ShaderManager->GetPixelShaderByKey(L"GOURAUD_StaticMeshPixelShader");
-        UpdateLitUnlitConstant(1);
-        break;
-    case EViewModeIndex::VMI_Lit_Lambert:
-        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
-        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
-        PixelShader = ShaderManager->GetPixelShaderByKey(L"LAMBERT_StaticMeshPixelShader");
-        UpdateLitUnlitConstant(1);
-        break;
-    case EViewModeIndex::VMI_Lit_BlinnPhong:
-        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
-        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
-        PixelShader = ShaderManager->GetPixelShaderByKey(L"PHONG_StaticMeshPixelShader");
-        UpdateLitUnlitConstant(1);
-        break;
-    case EViewModeIndex::VMI_LIT_PBR:
-        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
-        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
-        PixelShader = ShaderManager->GetPixelShaderByKey(L"PBR_StaticMeshPixelShader");
-        UpdateLitUnlitConstant(1);
-        break;
-    case EViewModeIndex::VMI_Wireframe:
-    case EViewModeIndex::VMI_Unlit:
-        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
-        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
-        PixelShader = ShaderManager->GetPixelShaderByKey(L"LAMBERT_StaticMeshPixelShader");
-        UpdateLitUnlitConstant(0);
-        break;
-    case EViewModeIndex::VMI_SceneDepth:
-        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
-        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
-        PixelShader = ShaderManager->GetPixelShaderByKey(L"StaticMeshPixelShaderDepth");
-        UpdateLitUnlitConstant(0);
-        break;
-    case EViewModeIndex::VMI_WorldNormal:
-        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
-        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
-        PixelShader = ShaderManager->GetPixelShaderByKey(L"StaticMeshPixelShaderWorldNormal");
-        UpdateLitUnlitConstant(0);
-        break;
-    case EViewModeIndex::VMI_WorldTangent:
-        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
-        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
-        PixelShader = ShaderManager->GetPixelShaderByKey(L"StaticMeshPixelShaderWorldTangent");
-        UpdateLitUnlitConstant(0);
-        break;
-    // HeatMap ViewMode 등
-    default:
-        VertexShader = ShaderManager->GetVertexShaderByKey(L"StaticMeshVertexShader");
-        InputLayout = ShaderManager->GetInputLayoutByKey(L"StaticMeshVertexShader");
-        PixelShader = ShaderManager->GetPixelShaderByKey(L"LAMBERT_StaticMeshPixelShader");
-        UpdateLitUnlitConstant(1);
-        break;
-    }
-
-    // Rasterizer
-    Graphics->ChangeRasterizer(ViewMode);
-
-    // Setup
-    Graphics->DeviceContext->VSSetShader(VertexShader, nullptr, 0);
-    Graphics->DeviceContext->IASetInputLayout(InputLayout);
-    Graphics->DeviceContext->PSSetShader(PixelShader, nullptr, 0);
-}
-
-void FStaticMeshRenderPass::Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManager)
-{
-    BufferManager = InBufferManager;
-    Graphics = InGraphics;
-    ShaderManager = InShaderManager;
-    
-    CreateShader();
-}
-
-void FStaticMeshRenderPass::InitializeShadowManager(class FShadowManager* InShadowManager)
-{
-    
-    ShadowManager = InShadowManager;
-}
 
 void FStaticMeshRenderPass::PrepareRenderArr()
 {
@@ -218,57 +55,48 @@ void FStaticMeshRenderPass::PrepareRenderArr()
     }
 }
 
-void FStaticMeshRenderPass::PrepareRenderState(const std::shared_ptr<FEditorViewportClient>& Viewport) 
+void FStaticMeshRenderPass::Render(const std::shared_ptr<FEditorViewportClient>& Viewport)
 {
-    const EViewModeIndex ViewMode = Viewport->GetViewMode();
+    ShadowManager->BindResourcesForSampling();
 
-    ChangeViewMode(ViewMode);
+    PrepareRenderState(Viewport);
 
-    Graphics->DeviceContext->IASetPrimitiveTopology(D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+    RenderAllStaticMeshes(Viewport);
 
-    TArray<FString> PSBufferKeys = {
-        TEXT("FLightInfoBuffer"),
-        TEXT("FMaterialConstants"),
-        TEXT("FLitUnlitConstants"),
-        TEXT("FSubMeshConstants"),
-        TEXT("FTextureConstants"),
-    };
+    // 렌더 타겟 해제
+    Graphics->DeviceContext->OMSetRenderTargets(0, nullptr, nullptr);
+    ID3D11ShaderResourceView* nullSRV = nullptr;
+    Graphics->DeviceContext->PSSetShaderResources(static_cast<int>(EShaderSRVSlot::SRV_PointLight), 1, &nullSRV); // t51 슬롯을 NULL로 설정
+    Graphics->DeviceContext->PSSetShaderResources(static_cast<int>(EShaderSRVSlot::SRV_DirectionalLight), 1, &nullSRV); // t51 슬롯을 NULL로 설정
+    Graphics->DeviceContext->PSSetShaderResources(static_cast<int>(EShaderSRVSlot::SRV_SpotLight), 1, &nullSRV); // t51 슬롯을 NULL로 설정
 
-    BufferManager->BindConstantBuffers(PSBufferKeys, 0, EShaderStage::Pixel);
-    BufferManager->BindConstantBuffer(TEXT("FDiffuseMultiplier"), 6, EShaderStage::Pixel);
+    // 머티리얼 리소스 해제
+    constexpr UINT NumViews = static_cast<UINT>(EMaterialTextureSlots::MTS_MAX);
 
-    BufferManager->BindConstantBuffer(TEXT("FLightInfoBuffer"), 0, EShaderStage::Vertex);
-    BufferManager->BindConstantBuffer(TEXT("FMaterialConstants"), 1, EShaderStage::Vertex);
-    BufferManager->BindConstantBuffer(TEXT("FObjectConstantBuffer"), 12, EShaderStage::Vertex);
-    
+    ID3D11ShaderResourceView* NullSRVs[NumViews] = { nullptr };
+    ID3D11SamplerState* NullSamplers[NumViews] = { nullptr };
 
-    Graphics->DeviceContext->RSSetViewports(1, &Viewport->GetViewportResource()->GetD3DViewport());
+    Graphics->DeviceContext->PSSetShaderResources(0, NumViews, NullSRVs);
+    Graphics->DeviceContext->PSSetSamplers(0, NumViews, NullSamplers);
 
-    const EResourceType ResourceType = EResourceType::ERT_Scene;
-    FViewportResource* ViewportResource = Viewport->GetViewportResource();
-    FRenderTargetRHI* RenderTargetRHI = ViewportResource->GetRenderTarget(ResourceType);
-    FDepthStencilRHI* DepthStencilRHI = ViewportResource->GetDepthStencil(ResourceType);
+    // for Gouraud shading
+    ID3D11ShaderResourceView* NullSRV[1] = { nullptr };
+    ID3D11SamplerState* NullSampler[1] = { nullptr };
+    Graphics->DeviceContext->VSSetShaderResources(0, 1, NullSRV);
+    Graphics->DeviceContext->VSSetSamplers(0, 1, NullSampler);
 
-    Graphics->DeviceContext->OMSetRenderTargets(1, &RenderTargetRHI->RTV, DepthStencilRHI->DSV);
+    // @todo 리소스 언바인딩 필요한가? - 답변: 네.
+    // SRV 해제
+    ID3D11ShaderResourceView* NullSRVs2[14] = { nullptr };
+    Graphics->DeviceContext->PSSetShaderResources(0, 14, NullSRVs2);
+
+    // 상수버퍼 해제
+    ID3D11Buffer* NullPSBuffer[9] = { nullptr };
+    Graphics->DeviceContext->PSSetConstantBuffers(0, 9, NullPSBuffer);
+    ID3D11Buffer* NullVSBuffer[2] = { nullptr };
+    Graphics->DeviceContext->VSSetConstantBuffers(0, 2, NullVSBuffer);
 }
 
-void FStaticMeshRenderPass::UpdateObjectConstant(const FMatrix& WorldMatrix, const FVector4& UUIDColor, bool bIsSelected) const
-{
-    FObjectConstantBuffer ObjectData = {};
-    ObjectData.WorldMatrix = WorldMatrix;
-    ObjectData.InverseTransposedWorld = FMatrix::Transpose(FMatrix::Inverse(WorldMatrix));
-    ObjectData.UUIDColor = UUIDColor;
-    ObjectData.bIsSelected = bIsSelected;
-    
-    BufferManager->UpdateConstantBuffer(TEXT("FObjectConstantBuffer"), ObjectData);
-}
-
-void FStaticMeshRenderPass::UpdateLitUnlitConstant(int32 isLit) const
-{
-    FLitUnlitConstants Data;
-    Data.bIsLit = isLit;
-    BufferManager->UpdateConstantBuffer(TEXT("FLitUnlitConstants"), Data);
-}
 
 void FStaticMeshRenderPass::RenderPrimitive(FStaticMeshRenderData* RenderData, TArray<FStaticMaterial*> Materials, TArray<UMaterial*> OverrideMaterials, int SelectedSubMeshIndex) const
 {
@@ -391,49 +219,6 @@ void FStaticMeshRenderPass::RenderAllStaticMeshes(const std::shared_ptr<FEditorV
             FEngineLoop::PrimitiveDrawBatch.AddAABBToBatch(Comp->GetBoundingBox(), Comp->GetWorldLocation(), WorldMatrix);
         }
     }
-}
-
-void FStaticMeshRenderPass::Render(const std::shared_ptr<FEditorViewportClient>& Viewport)
-{
-    ShadowManager->BindResourcesForSampling();
-
-    PrepareRenderState(Viewport);
-
-    RenderAllStaticMeshes(Viewport);
-
-    // 렌더 타겟 해제
-    Graphics->DeviceContext->OMSetRenderTargets(0, nullptr, nullptr);
-    ID3D11ShaderResourceView* nullSRV = nullptr;
-    Graphics->DeviceContext->PSSetShaderResources(static_cast<int>(EShaderSRVSlot::SRV_PointLight), 1, &nullSRV); // t51 슬롯을 NULL로 설정
-    Graphics->DeviceContext->PSSetShaderResources(static_cast<int>(EShaderSRVSlot::SRV_DirectionalLight), 1, &nullSRV); // t51 슬롯을 NULL로 설정
-    Graphics->DeviceContext->PSSetShaderResources(static_cast<int>(EShaderSRVSlot::SRV_SpotLight), 1, &nullSRV); // t51 슬롯을 NULL로 설정
-
-    // 머티리얼 리소스 해제
-    constexpr UINT NumViews = static_cast<UINT>(EMaterialTextureSlots::MTS_MAX);
-    
-    ID3D11ShaderResourceView* NullSRVs[NumViews] = { nullptr };
-    ID3D11SamplerState* NullSamplers[NumViews] = { nullptr};
-    
-    Graphics->DeviceContext->PSSetShaderResources(0, NumViews, NullSRVs);
-    Graphics->DeviceContext->PSSetSamplers(0, NumViews, NullSamplers);
-
-    // for Gouraud shading
-    ID3D11ShaderResourceView* NullSRV[1] = { nullptr };
-    ID3D11SamplerState* NullSampler[1] = { nullptr};
-    Graphics->DeviceContext->VSSetShaderResources(0, 1, NullSRV);
-    Graphics->DeviceContext->VSSetSamplers(0, 1, NullSampler);
-    
-    // @todo 리소스 언바인딩 필요한가? - 답변: 네.
-    // SRV 해제
-    ID3D11ShaderResourceView* NullSRVs2[14] = { nullptr };
-    Graphics->DeviceContext->PSSetShaderResources(0, 14, NullSRVs2);
-
-    // 상수버퍼 해제
-    ID3D11Buffer* NullPSBuffer[9] = { nullptr };
-    Graphics->DeviceContext->PSSetConstantBuffers(0, 9, NullPSBuffer);
-    ID3D11Buffer* NullVSBuffer[2] = { nullptr };
-    Graphics->DeviceContext->VSSetConstantBuffers(0, 2, NullVSBuffer);
-
 }
 
 void FStaticMeshRenderPass::ClearRenderArr()

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/StaticMeshRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/StaticMeshRenderPass.h
@@ -45,12 +45,4 @@ protected:
 
     TArray<UStaticMeshComponent*> StaticMeshComponents;
 
-    /*
-    ID3D11VertexShader* VertexShader;
-    ID3D11InputLayout* InputLayout;
-    
-    ID3D11PixelShader* PixelShader;
-    ID3D11PixelShader* DebugDepthShader;
-    ID3D11PixelShader* DebugWorldNormalShader;
-    */
 };

--- a/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/StaticMeshRenderPass.h
+++ b/EngineSIU/EngineSIU/Engine/Source/Runtime/Renderer/StaticMeshRenderPass.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "IRenderPass.h"
+#include "MeshRenderPass.h"
 #include "EngineBaseTypes.h"
 #include "Container/Set.h"
 
@@ -16,16 +16,12 @@ class UStaticMeshComponent;
 struct FStaticMaterial;
 class FShadowRenderPass;
 
-class FStaticMeshRenderPass : public IRenderPass
+class FStaticMeshRenderPass : public FMeshRenderPassBase
 {
 public:
     FStaticMeshRenderPass();
     
     virtual ~FStaticMeshRenderPass();
-    
-    virtual void Initialize(FDXDBufferManager* InBufferManager, FGraphicsDevice* InGraphics, FDXDShaderManager* InShaderManager) override;
-    
-    void InitializeShadowManager(class FShadowManager* InShadowManager);
     
     virtual void PrepareRenderArr() override;
 
@@ -34,25 +30,15 @@ public:
     virtual void ClearRenderArr() override;
     void RenderAllStaticMeshesForPointLight(const std::shared_ptr<FEditorViewportClient>& Viewport, UPointLightComponent*& PointLight);
 
-    virtual void PrepareRenderState(const std::shared_ptr<FEditorViewportClient>& Viewport);
-
     virtual void RenderAllStaticMeshes(const std::shared_ptr<FEditorViewportClient>& Viewport);
-    
-    void UpdateObjectConstant(const FMatrix& WorldMatrix, const FVector4& UUIDColor, bool bIsSelected) const;
-  
-    void UpdateLitUnlitConstant(int32 isLit) const;
 
     void RenderPrimitive(FStaticMeshRenderData* RenderData, TArray<FStaticMaterial*> Materials, TArray<UMaterial*> OverrideMaterials, int SelectedSubMeshIndex) const;
     
-    void RenderPrimitive(ID3D11Buffer* pBuffer, UINT numVertices) const;
+    void RenderPrimitive(ID3D11Buffer* pBuffer, UINT numVertices) const override;
 
-    void RenderPrimitive(ID3D11Buffer* pVertexBuffer, UINT numVertices, ID3D11Buffer* pIndexBuffer, UINT numIndices) const;
+    void RenderPrimitive(ID3D11Buffer* pVertexBuffer, UINT numVertices, ID3D11Buffer* pIndexBuffer, UINT numIndices) const override;
 
-    // Shader 관련 함수 (생성/해제 등)
-    void CreateShader();
-    void ReleaseShader();
-
-    void ChangeViewMode(EViewModeIndex ViewMode);
+    // Shader 관련 함수 (생성/해제 등) // FMeshRenderPass에서 구현했습니다.
     
 protected:
 
@@ -67,10 +53,4 @@ protected:
     ID3D11PixelShader* DebugDepthShader;
     ID3D11PixelShader* DebugWorldNormalShader;
     */
-
-    FDXDBufferManager* BufferManager;
-    FGraphicsDevice* Graphics;
-    FDXDShaderManager* ShaderManager;
-    
-    FShadowManager* ShadowManager;
 };

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj
@@ -304,10 +304,12 @@
     <ClCompile Include="Engine\Source\Runtime\Renderer\GizmoRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\LightHeatMapRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\LineRenderPass.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Renderer\MeshRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\PostProcessCompositingPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\Renderer.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\ShadowManager.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\ShadowRenderPass.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Renderer\SkeletalMeshRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\SlateRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\StaticMeshRenderPass.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Renderer\StaticMeshRenderPassBase.cpp" />
@@ -585,6 +587,7 @@
     <ClInclude Include="Engine\Source\Runtime\Renderer\IRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\LightHeatMapRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\LineRenderPass.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\MeshRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\PostProcessCompositingPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\Renderer.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\RendererHelpers.h" />
@@ -592,6 +595,7 @@
     <ClInclude Include="Engine\Source\Runtime\Renderer\ShaderConstants.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\ShadowManager.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\ShadowRenderPass.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\SkeletalMeshRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\SlateRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\StaticMeshRenderPass.h" />
     <ClInclude Include="Engine\Source\Runtime\Renderer\StaticMeshRenderPassBase.h" />

--- a/EngineSIU/EngineSIU/EngineSIU.vcxproj.filters
+++ b/EngineSIU/EngineSIU/EngineSIU.vcxproj.filters
@@ -819,6 +819,12 @@
     <ClCompile Include="Engine\Source\Runtime\Core\Math\MathUtility.cpp" />
     <ClCompile Include="Engine\Source\Contents\Objects\DamageCameraShake.cpp" />
     <ClCompile Include="Engine\Source\Runtime\Engine\Classes\Camera\PerlinNoiseCameraShakePattern.cpp" />
+    <ClCompile Include="Engine\Source\Runtime\Renderer\MeshRenderPass.cpp">
+      <Filter>Engine\Source\Runtime\Renderer</Filter>
+    </ClCompile>
+    <ClCompile Include="Engine\Source\Runtime\Renderer\SkeletalMeshRenderPass.cpp">
+      <Filter>Engine\Source\Runtime\Renderer</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Natvis Include="EngineSIU.natvis" />
@@ -939,6 +945,12 @@
     <ClInclude Include="Engine\Source\Contents\Actors\TriggerBox.h" />
     <ClInclude Include="Engine\Source\Contents\Objects\DamageCameraShake.h" />
     <ClInclude Include="Engine\Source\Runtime\Engine\Classes\Camera\PerlinNoiseCameraShakePattern.h" />
+    <ClInclude Include="Engine\Source\Runtime\Renderer\MeshRenderPass.h">
+      <Filter>Engine\Source\Runtime\Renderer</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Source\Runtime\Renderer\SkeletalMeshRenderPass.h">
+      <Filter>Engine\Source\Runtime\Renderer</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="Shaders\SlateShader.hlsl" />


### PR DESCRIPTION
## 주요 변경사항

- Skeletal과 Static Mesh의 Render Pass 분리를 위해 작업 진행하였습니다.
- Skeletal과 Static Render Pass 중 겹치는 부분은 FMeshRenderPassBase라는 부모 클래스를 만들어 넣어두었고
- 둘이 다른 부분에 대해서 Skeletal  과 Static에서 override하거나 함수를 추가하여 처리하도록 의도했습니다.
- Static은 정상작동하는 것을 확인하였고 Skeletal은 TODO 부분을 다 채우면 정상작동 할 것으로 보입니다.

